### PR TITLE
Migrate Plugins to Jakarta EE 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.iml
+target/

--- a/commons-lang-plugin/pom.xml
+++ b/commons-lang-plugin/pom.xml
@@ -4,7 +4,8 @@
 	<artifactId>jaxb2-commons-lang</artifactId>
 	<packaging>jar</packaging>
 
-	<version>2.5-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
+<!--	<version>2.5-SNAPSHOT</version>-->
 
 	<name>JAXB2 Commons - Commons Lang Plugin</name>
 
@@ -50,16 +51,16 @@
 	</scm>
 	
 	<dependencies>
-		<dependency>  
-			<groupId>com.sun.xml.bind</groupId>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-xjc</artifactId>
-			<version>2.1.13</version>
+			<version>3.0.2</version>
 			<scope>provided</scope>
-		</dependency>  
+		</dependency>
 		<dependency>  
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.2.1</version>
+			<version>3.12.0</version>
 		</dependency>  
 	</dependencies>
 	
@@ -70,8 +71,8 @@
 					<inherited>true</inherited>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<source>1.5</source>
-						<target>1.5</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/default-value-plugin/pom.xml
+++ b/default-value-plugin/pom.xml
@@ -4,7 +4,8 @@
 	<artifactId>jaxb2-default-value</artifactId>
 	<packaging>jar</packaging>
 
-	<version>1.2-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
+<!--	<version>1.2-SNAPSHOT</version>-->
 
 	<name>JAXB2 Commons - Default Value Plugin</name>
 
@@ -50,12 +51,12 @@
 	</scm>
 	
 	<dependencies>
-		<dependency>  
-			<groupId>com.sun.xml.bind</groupId>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-xjc</artifactId>
-			<version>2.1.13</version>
+			<version>3.0.2</version>
 			<scope>provided</scope>
-		</dependency>  
+		</dependency>
 	</dependencies>
 	
 	<build>
@@ -65,8 +66,8 @@
 					<inherited>true</inherited>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<source>1.5</source>
-						<target>1.5</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/fluent-api/pom.xml
+++ b/fluent-api/pom.xml
@@ -4,7 +4,8 @@
 	<artifactId>jaxb2-fluent-api</artifactId>
 	<packaging>jar</packaging>
 
-	<version>3.1-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
+<!--	<version>3.1-SNAPSHOT</version>-->
 
 	<name>JAXB2 Commons - Fluent API Plugin</name>
 
@@ -50,23 +51,24 @@
 	</scm>
 	
 	<dependencies>
-		<dependency>  
-			<groupId>com.sun.xml.bind</groupId>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-xjc</artifactId>
-			<version>2.1.13</version>
+			<version>3.0.2</version>
 			<scope>provided</scope>
-		</dependency>  
+		</dependency>
 	</dependencies>
 	
 	<build>
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<version>3.10.1</version>
 					<inherited>true</inherited>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<source>1.5</source>
-						<target>1.5</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 			</plugins>
@@ -74,6 +76,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
+				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<id>attach-source</id>

--- a/namespace-prefix/pom.xml
+++ b/namespace-prefix/pom.xml
@@ -5,7 +5,8 @@
 	<artifactId>jaxb2-namespace-prefix</artifactId>
 	<packaging>jar</packaging>
 
-	<version>1.2-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
+<!--	<version>1.2-SNAPSHOT</version>-->
 
 	<name>JAXB2 - Namespace Prefix Plugin</name>
 
@@ -47,9 +48,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
+			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-xjc</artifactId>
-			<version>2.1.13</version>
+			<version>3.0.2</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -61,8 +62,8 @@
 					<inherited>true</inherited>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 			</plugins>
@@ -93,6 +94,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
+				<version>3.0.1</version>
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>

--- a/namespace-prefix/src/main/java/org/jvnet/jaxb2_commons/plugin/namespace_prefix/NamespacePrefixPlugin.java
+++ b/namespace-prefix/src/main/java/org/jvnet/jaxb2_commons/plugin/namespace_prefix/NamespacePrefixPlugin.java
@@ -1,7 +1,7 @@
 package org.jvnet.jaxb2_commons.plugin.namespace_prefix;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,9 +33,9 @@ import com.sun.xml.xsom.impl.SchemaImpl;
 import org.xml.sax.ErrorHandler;
 
 /**
- * This plugin adds {@link javax.xml.bind.annotation.XmlNs} annotations to <i>package-info.java</i> files. Those annotations tells Jaxb2 to generate XML schema's instances with specific namespaces
+ * This plugin adds {@link jakarta.xml.bind.annotation.XmlNs} annotations to <i>package-info.java</i> files. Those annotations tells Jaxb2 to generate XML schema's instances with specific namespaces
  * prefixes, instead of the auto-generated (ns1, ns2, ...) prefixes. Definition of thoses prefixes is done in the bindings.xml file.
- * <p/>
+ * <p>
  * Bindings.xml file example:
  * <pre>
  *  &lt;?xml version=&quot;1.0&quot;?&gt;

--- a/value-constructor/pom.xml
+++ b/value-constructor/pom.xml
@@ -3,8 +3,9 @@
 	<groupId>org.jvnet.jaxb2_commons</groupId>
 	<artifactId>jaxb2-value-constructor</artifactId>
 	<packaging>jar</packaging>
-	<version>3.1-SNAPSHOT</version>
-	
+	<version>4.0.0-SNAPSHOT</version>
+<!--	<version>3.1-SNAPSHOT</version>-->
+
 	<name>JAXB2 Commons - Value Constructor Plugin</name>
 
 	<url>http://java.net/projects/jaxb2-commons/pages/value-constructor</url>
@@ -50,12 +51,12 @@
 	</scm>
 
 	<dependencies>
-		<dependency>  
-			<groupId>com.sun.xml.bind</groupId>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-xjc</artifactId>
-			<version>2.1.13</version>
+			<version>3.0.2</version>
 			<scope>provided</scope>
-		</dependency>  
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -65,8 +66,8 @@
 					<inherited>true</inherited>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<source>1.5</source>
-						<target>1.5</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
Maybe someone is still watching this...

I'm interested in moving the following plugins into the new Jakarta EE 9 era...

- jaxb2-commons-lang
- jaxb2-default-value
- jaxb2-fluent-api
- jaxb2-namespace-prefix
- jaxb2-value-constructor

The jaxb2-basics plugin moved to https://github.com/highsource/jaxb2-basics IIRC.

What I did:

- Upgrade to org.glassfish.jaxb:jaxb-xjc:3.0.2
- Use jakara.* imports where applicable.
- Set Source and Target compatibility to 1.8

I case there are successors to this repos which I missed - any help appreciated.